### PR TITLE
유저 히스토리 조회 및 추가

### DIFF
--- a/src/database/pointhistory.table.ts
+++ b/src/database/pointhistory.table.ts
@@ -36,9 +36,4 @@ export class PointHistoryTable {
       r(this.table.filter((v) => v.userId == userId));
     });
   }
-
-  reset() {
-    this.table.length = 0;
-    this.cursor = 1;
-  }
 }

--- a/src/point/point.controller.ts
+++ b/src/point/point.controller.ts
@@ -7,15 +7,13 @@ import {
   Patch,
   ValidationPipe,
 } from '@nestjs/common';
-import { UserPoint } from './point.model';
-import { PointHistoryTable } from '../database/pointhistory.table';
+import { PointHistory, UserPoint } from './point.model';
 import { PointBody as PointDto } from './point.dto';
 import { PointService } from './point.service';
 
 @Controller('/point')
 export class PointController {
   constructor(
-    private readonly historyDb: PointHistoryTable,
     private readonly pointService: PointService,
   ) {}
 
@@ -27,14 +25,13 @@ export class PointController {
     return this.pointService.getPoint(id);
   }
 
-  //   /**
-  //    * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
-  //    */
-  //   @Get(':id/histories')
-  //   async history(@Param('id') id): Promise<PointHistory[]> {
-  //     const userId = Number.parseInt(id);
-  //     return [];
-  //   }
+  /**
+   * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
+   */
+  @Get(':id/histories')
+  async history(@Param('id') id): Promise<PointHistory[]> {
+    return this.pointService.getHistory(id);
+  }
 
   /**
    * TODO - 특정 유저의 포인트를 충전하는 기능을 작성해주세요.

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -27,7 +27,7 @@ describe('AppController (e2e)', () => {
     expect(res.body).toEqual({
       id: 1,
       point: 0,
-      updateMillis: expect.any(Number),
+      updateMillis: expect.any(Number), // 시간 타입 검증
     });
   });
 
@@ -82,7 +82,7 @@ describe('AppController (e2e)', () => {
     // test를 위한 충전
     await request(app.getHttpServer())
       .patch('/point/1/charge')
-      .send({amount: 100})
+      .send({ amount : 100 })
       .expect(200);
 
     // point 사용
@@ -110,6 +110,44 @@ describe('AppController (e2e)', () => {
       message: 'Internal server error',
       statusCode: 500,
     });
+  });
+
+  // 유저 포인트 거래내역 확인
+  it('/point/:id/histories (GET)', async () => {
+    // test를 위한 충전
+    await request(app.getHttpServer())
+      .patch('/point/1/charge')
+      .send({ amount : 100 })
+      .expect(200);
+    // test를 위한 사용
+    await request(app.getHttpServer())
+      .patch('/point/1/use')
+      .send({ amount : 100})
+      .expect(200);
+
+    // 로그 조회
+    const res = await request(app.getHttpServer())
+      .get('/point/1/histories')
+      .expect(200);
+    
+    // test 응답값
+    expect(res.body).toEqual(
+    [
+      {
+        amount: 100, 
+        id: 1, 
+        timeMillis: expect.any(Number), 
+        type: 0, 
+        userId: 1
+      },
+      {
+        amount: 0, 
+        id: 2, 
+        timeMillis: expect.any(Number), 
+        type: 1, 
+        userId: 1
+      }
+    ]);
   });
 
   // 끝점


### PR DESCRIPTION
### 이런 이유로 코드를 변경했어요.
- pointService에서 histories로직 추가
`    
    // 결과 저장
    const result = await this.userDb.insertOrUpdate(userId, usedAmount);
    // 로그 저장
    await this.pointHistoryTable.insert(result.id, result.point, TransactionType.USE, Date.now());
    return result;
  }
`
- e2e Test
`
// 유저 포인트 거래내역 확인
  it('/point/:id/histories (GET)', async () => {
    // test를 위한 충전
    await request(app.getHttpServer())
      .patch('/point/1/charge')
      .send({ amount : 100 })
      .expect(200);
    // test를 위한 사용
    await request(app.getHttpServer())
      .patch('/point/1/use')
      .send({ amount : 100})
      .expect(200);

    // 로그 조회
    const res = await request(app.getHttpServer())
      .get('/point/1/histories')
      .expect(200);

    // test 응답값
    expect(res.body).toEqual(
    [
      {
        amount: 100, 
        id: 1, 
        timeMillis: expect.any(Number), 
        type: 0, 
        userId: 1
      },
      {
        amount: 0, 
        id: 2, 
        timeMillis: expect.any(Number), 
        type: 1, 
        userId: 1
      }
    ]);
  });

`



### 이 부분을 집중해서 봐주세요.
- e2e 검증 과정에서 날짜를 아래와 같이 검증하는게 맞는지 
`
timeMillis: expect.any(Number), 
`

